### PR TITLE
Allow users to pass in a `:retries` option for the I2C transport

### DIFF
--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -34,12 +34,13 @@ defmodule SHT4X do
   def init(init_arg) do
     bus_name = init_arg[:bus_name] || @default_bus_name
     bus_address = @bus_address
+    num_retries = init_arg[:retries] || 0
 
     Logger.info(
       "[SHT4X] Starting on bus #{bus_name} at address #{inspect(bus_address, base: :hex)}"
     )
 
-    transport = SHT4X.Transport.new(bus_name, bus_address)
+    transport = SHT4X.Transport.new(bus_name, bus_address, num_retries)
 
     case SHT4X.Comm.serial_number(transport) do
       {:ok, serial_number} ->

--- a/lib/sht4x/comm.ex
+++ b/lib/sht4x/comm.ex
@@ -38,9 +38,9 @@ defmodule SHT4X.Comm do
 
   @spec read_data(Transport.t(), iodata, non_neg_integer()) :: {:ok, <<_::48>>}
   defp read_data(transport, command, delay_ms \\ 1) do
-    with :ok <- transport.write_fn.(command),
+    with :ok <- transport.write_fn.(command, retries: transport.num_retries),
          :ok <- Process.sleep(delay_ms) do
-      transport.read_fn.(6)
+      transport.read_fn.(6, retries: transport.num_retries)
     end
   end
 end

--- a/lib/sht4x/transport.ex
+++ b/lib/sht4x/transport.ex
@@ -5,27 +5,29 @@ defmodule SHT4X.Transport do
 
   typedstruct do
     field(:address, 0..127, enforce: true)
-    field(:read_fn, (pos_integer -> {:ok, binary} | {:error, any}), enforce: true)
+    field(:read_fn, (pos_integer, Keyword.t() -> {:ok, binary} | {:error, any}), enforce: true)
     field(:ref, reference, enforce: true)
-    field(:write_fn, (iodata -> :ok | {:error, any}), enforce: true)
+    field(:write_fn, (iodata, Keyword.t() -> :ok | {:error, any}), enforce: true)
     field(:write_read_fn, (iodata, pos_integer -> {:ok, binary} | {:error, any}), enforce: true)
+    field(:num_retries, pos_integer(), enforce: true)
   end
 
-  @spec new(reference, 0..127) :: SHT4X.Transport.t()
-  def new(ref, address) when is_reference(ref) and is_integer(address) do
+  @spec new(reference, 0..127, pos_integer()) :: SHT4X.Transport.t()
+  def new(ref, address, retries) when is_reference(ref) and is_integer(address) and is_integer(retries) do
     %__MODULE__{
       ref: ref,
       address: address,
-      read_fn: &Circuits.I2C.read(ref, address, &1),
-      write_fn: &Circuits.I2C.write(ref, address, &1),
-      write_read_fn: &Circuits.I2C.write_read(ref, address, &1, &2)
+      read_fn: &Circuits.I2C.read(ref, address, &1, &2),
+      write_fn: &Circuits.I2C.write(ref, address, &1, &2),
+      write_read_fn: &Circuits.I2C.write_read(ref, address, &1, &2),
+      num_retries: retries
     }
   end
 
-  @spec new(binary, 0..127) :: SHT4X.Transport.t()
-  def new(bus_name, address) when is_binary(bus_name) and is_integer(address) do
+  @spec new(binary, 0..127, pos_integer()) :: SHT4X.Transport.t()
+  def new(bus_name, address, retries) when is_binary(bus_name) and is_integer(address) and is_integer(retries) do
     ref = open_i2c!(bus_name)
-    new(ref, address)
+    new(ref, address, retries)
   end
 
   @spec open_i2c!(binary) :: reference


### PR DESCRIPTION
The Circuits I2C library allows you to pass in a `:retries` option when calling write/read etc. 

If a device or a bus is flaky it may be beneficial to allow a maximum retry option that gets passed down into the I2C library, to avoid the entire process crashing from just a small hiccup, which is something we've run into on a particular development board internally.

Thanks!