### PR TITLE
Catch errors from the transport initialization

### DIFF
--- a/lib/sht4x/transport.ex
+++ b/lib/sht4x/transport.ex
@@ -28,7 +28,7 @@ defmodule SHT4X.Transport do
      }}
   end
 
-  @spec new(binary, 0..127, non_neg_integer) :: t()
+  @spec new(binary, 0..127, non_neg_integer) :: {:ok, t()} | {:error, any}
   def new(bus_name, address, retries)
       when is_binary(bus_name) and is_integer(address) and is_integer(retries) do
     case Circuits.I2C.open(bus_name) do

--- a/lib/sht4x/transport.ex
+++ b/lib/sht4x/transport.ex
@@ -12,31 +12,31 @@ defmodule SHT4X.Transport do
     field(:write_read_fn, (iodata, pos_integer -> {:ok, binary} | {:error, any}), enforce: true)
   end
 
-  @spec new(reference, 0..127, non_neg_integer) :: t()
+  @spec new(reference, 0..127, non_neg_integer) :: {:ok, t()} | {:error, any}
   def new(ref, address, retries)
       when is_reference(ref) and is_integer(address) and is_integer(retries) do
     opts = [retries: retries]
 
-    %__MODULE__{
-      ref: ref,
-      address: address,
-      retries: retries,
-      read_fn: &Circuits.I2C.read(ref, address, &1, opts),
-      write_fn: &Circuits.I2C.write(ref, address, &1, opts),
-      write_read_fn: &Circuits.I2C.write_read(ref, address, &1, &2, opts)
-    }
+    {:ok,
+     %__MODULE__{
+       ref: ref,
+       address: address,
+       retries: retries,
+       read_fn: &Circuits.I2C.read(ref, address, &1, opts),
+       write_fn: &Circuits.I2C.write(ref, address, &1, opts),
+       write_read_fn: &Circuits.I2C.write_read(ref, address, &1, &2, opts)
+     }}
   end
 
   @spec new(binary, 0..127, non_neg_integer) :: t()
   def new(bus_name, address, retries)
       when is_binary(bus_name) and is_integer(address) and is_integer(retries) do
-    ref = open_i2c!(bus_name)
-    new(ref, address, retries)
-  end
+    case Circuits.I2C.open(bus_name) do
+      {:error, err} ->
+        {:error, err}
 
-  @spec open_i2c!(binary) :: reference
-  defp open_i2c!(bus_name) do
-    {:ok, ref} = Circuits.I2C.open(bus_name)
-    ref
+      {:ok, ref} ->
+        new(ref, address, retries)
+    end
   end
 end


### PR DESCRIPTION
Currently, if a bus or device is not present, or is flaky, the entire GenServer will crash, causing the caller to crash with no clean way to catch the exit. (In particular I was running into a `BadMatch` error inside the GenServer `init` callback.)

This refactors the transport initialization, and the `SHT4X.start_link/1` function will now return either `{:ok, pid}` or `{:error, ...}` allowing the caller to recover from a failed startup.

Example log with new error logic:

```
09:40:25.858 [info]  [SHT4X] Starting on bus i2c-0 at address 0x44
 
09:40:25.862 [error] [SHT4X] Error connecting to sensor: bus_not_found
```