### PR TITLE
test: loosen type check for I2C return value

### DIFF
--- a/lib/sht4x/transport.ex
+++ b/lib/sht4x/transport.ex
@@ -5,16 +5,26 @@ defmodule SHT4X.Transport do
 
   typedstruct do
     field(:address, 0..127, enforce: true)
-    field(:ref, reference, enforce: true)
+    field(:ref, any, enforce: true)
     field(:retries, non_neg_integer, default: 0)
     field(:read_fn, (pos_integer -> {:ok, binary} | {:error, any}), enforce: true)
     field(:write_fn, (iodata -> :ok | {:error, any}), enforce: true)
     field(:write_read_fn, (iodata, pos_integer -> {:ok, binary} | {:error, any}), enforce: true)
   end
 
-  @spec new(reference, 0..127, non_neg_integer) :: {:ok, t()} | {:error, any}
-  def new(ref, address, retries)
-      when is_reference(ref) and is_integer(address) and is_integer(retries) do
+  @spec new(any, 0..127, non_neg_integer) :: {:ok, t()} | {:error, any}
+  def new(bus_name, address, retries) when is_binary(bus_name) do
+    case Circuits.I2C.open(bus_name) do
+      {:error, err} ->
+        {:error, err}
+
+      {:ok, ref} ->
+        new(ref, address, retries)
+    end
+  end
+
+  # We want to allow ref to be of any type so that we can use sim etc as needed.
+  def new(ref, address, retries) when is_integer(address) and is_integer(retries) do
     opts = [retries: retries]
 
     {:ok,
@@ -26,17 +36,5 @@ defmodule SHT4X.Transport do
        write_fn: &Circuits.I2C.write(ref, address, &1, opts),
        write_read_fn: &Circuits.I2C.write_read(ref, address, &1, &2, opts)
      }}
-  end
-
-  @spec new(binary, 0..127, non_neg_integer) :: {:ok, t()} | {:error, any}
-  def new(bus_name, address, retries)
-      when is_binary(bus_name) and is_integer(address) and is_integer(retries) do
-    case Circuits.I2C.open(bus_name) do
-      {:error, err} ->
-        {:error, err}
-
-      {:ok, ref} ->
-        new(ref, address, retries)
-    end
   end
 end


### PR DESCRIPTION
Long story short we want to loosen type checks for i2c references.

This is a minor adjustment for type checks so we can potentially take advantage of [circuits_sim]. 

[circuits_sim]: https://github.com/elixir-circuits/circuits_sim/blob/main/lib/circuits_sim/device/b5ze.ex

related: https://github.com/elixir-circuits/circuits_sim/pull/6