### PR TITLE
Don't define defaults in the typedstruct def, fix incorrect options doc

### DIFF
--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -16,9 +16,9 @@ defmodule SHT4X do
   SHT4X GenServer start_link options
   * `:name` - a name for the GenServer
   * `:bus_name` - which I2C bus to use (e.g., `"i2c-1"`)
-  * `:retries` - the number of retries before failing (defaults to no retries)
+  * `:retries` - the number of retries before failing (defaults to 3 retries)
   * `:compensation_callback` - a function that takes in a `SHT4X.Measurement.t()` and returns a potentially modified `SHT4X.Measurement.t()`
-  * `:measurement_interval` - how often data will be read from the sensor
+  * `:measurement_interval` - how often data will be read from the sensor (defaults to 5_000 ms)
   * `:repeatability` - accuracy of the requested sensor read (`:low`, `:medium`, or `:high`)
   * Also accepts all other standard `GenServer` start_link options
   """

--- a/lib/sht4x/transport.ex
+++ b/lib/sht4x/transport.ex
@@ -7,7 +7,7 @@ defmodule SHT4X.Transport do
     field(:address, Circuits.I2C.address(), enforce: true)
     # We want to allow ref to be of any type so that we can use sim etc as needed.
     field(:ref, any, enforce: true)
-    field(:retries, non_neg_integer, default: 0)
+    field(:retries, non_neg_integer, enforce: true)
     field(:read_fn, (pos_integer -> {:ok, binary} | {:error, any}), enforce: true)
     field(:write_fn, (iodata -> :ok | {:error, any}), enforce: true)
     field(:write_read_fn, (iodata, pos_integer -> {:ok, binary} | {:error, any}), enforce: true)


### PR DESCRIPTION
* Corrects documentation in `SHT4X` module to declare correct default number of retries
* Removes confusing (and unused) default from the `Transport` struct