### PR TITLE
Use cerlc to compute the CRC

### DIFF
--- a/lib/sht4x/comm.ex
+++ b/lib/sht4x/comm.ex
@@ -40,23 +40,12 @@ defmodule SHT4X.Comm do
   defp delay_ms_for_measure(:medium), do: 4
   defp delay_ms_for_measure(:high), do: 8
 
-  defp check_crc(<<raw_t1, raw_t2, crc1, raw_rh1, raw_rh2, crc2>> = binary) do
-    computed_crc1 = Calc.checksum(<<raw_t1, raw_t2>>)
-    computed_crc2 = Calc.checksum(<<raw_rh1, raw_rh2>>)
-
-    if computed_crc1 == crc1 && computed_crc2 == crc2 do
-      {:ok, binary}
-    else
-      :error
-    end
-  end
-
   @spec read_data(Transport.t(), iodata, non_neg_integer()) :: {:ok, <<_::48>>} | :error
   defp read_data(transport, command, delay_ms \\ 1) do
     with :ok <- transport.write_fn.(command),
          :ok <- Process.sleep(delay_ms),
          {:ok, binary} <- transport.read_fn.(6),
-         {:ok, binary} <- check_crc(binary) do
+         true <- Calc.crc_ok?(binary) do
       {:ok, binary}
     else
       _ -> :error

--- a/mix.exs
+++ b/mix.exs
@@ -44,6 +44,7 @@ defmodule SHT4X.MixProject do
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.28", only: :docs, runtime: false},
       {:mix_test_watch, "~> 1.1", only: :dev, runtime: false},
+      {:cerlc, "~> 0.2.0"},
       {:typed_struct, "~> 0.3.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
+  "cerlc": {:hex, :cerlc, "0.2.1", "cfe0880aa049ebcca079ca49578055aa48e7f2e9ed8ae08bd1f919d59015d03f", [:rebar3], [], "hexpm", "37f0d74a4277dcbaf64c7c47e9953dcc8060d26d86bb466ab2a86928e0181a7d"},
   "circuits_i2c": {:hex, :circuits_i2c, "1.2.2", "1666bf1763fe60ab835462d13f04ca75b0de000a7d5b89e24d8f35a06ef6d097", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "a7fffcb1bf128e4112b0734796f26b0b4f2359e4c60e86d9718c31834e10a343"},
   "credo": {:hex, :credo, "1.7.0", "6119bee47272e85995598ee04f2ebbed3e947678dee048d10b5feca139435f75", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "6839fcf63d1f0d1c0f450abc8564a57c43d644077ab96f2934563e68b8a769d7"},
   "dialyxir": {:hex, :dialyxir, "1.3.0", "fd1672f0922b7648ff9ce7b1b26fcf0ef56dda964a459892ad15f6b4410b5284", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "00b2a4bcd6aa8db9dcb0b38c1225b7277dca9bc370b6438715667071a304696f"},

--- a/test/sht4x/calc_test.exs
+++ b/test/sht4x/calc_test.exs
@@ -1,5 +1,5 @@
 defmodule SHT4X.CalcTest do
   use ExUnit.Case, async: true
-  import SHT4X.Calc
+
   doctest SHT4X.Calc
 end


### PR DESCRIPTION
The cerlc library should be a little safer to use due to its tests. Plus
the Sensirion CRC is built-in. There's also a small chance that it's
trivially faster.
