### PR TITLE
Rename `measure/1` -> `get_sample/1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,15 @@ Read temperature and humidity from [Sensirion SHT4x sensors](https://www.sensiri
 iex> {:ok, sht} = SHT4X.start_link(bus_name: "i2c-1")
 {:ok, #PID<0.2190.0>}
 
-iex> SHT4X.measure(sht)
-{:ok,
-  %SHT4X.Measurement{
-    timestamp_ms: 498436,
-    raw_reading_humidity: 28080,
-    raw_reading_temperature: 26379,
-    temperature_c: 22.38528060913086,
-    humidity_rh: 57.131805419921875,
-    dew_point_c: 13.492363250293858
-  }}
+iex> SHT4X.get_sample(sht)
+%SHT4X.Measurement{
+  timestamp_ms: 498436,
+  raw_reading_humidity: 28080,
+  raw_reading_temperature: 26379,
+  temperature_c: 22.38528060913086,
+  humidity_rh: 57.131805419921875,
+  dew_point_c: 13.492363250293858
+}
 ```
 
 For details, see [API reference](https://hexdocs.pm/sht4x/api-reference.html).


### PR DESCRIPTION
Renames the SHT `measure` function to `get_sample` to avoid confusion, since this function no longer causes a read on the i2c line. Instead, it fetches the freshest value from the sensor's GenServer.

This also removes the `:ok` tuple wrapped around the measurement result, in preparation for a more robust `get_sample/1` function.