### PR TITLE
Check for stale samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ iex> SHT4X.get_sample(sht)
   raw_reading_temperature: 26379,
   temperature_c: 22.38528060913086,
   humidity_rh: 57.131805419921875,
-  dew_point_c: 13.492363250293858
+  dew_point_c: 13.492363250293858,
+  quality: :fresh
 }
 ```
 

--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -91,7 +91,15 @@ defmodule SHT4X do
         :stale_threshold
       ])
 
-    GenServer.start_link(__MODULE__, init_arg, gen_server_opts)
+    case GenServer.start_link(__MODULE__, init_arg, gen_server_opts) do
+      {:ok, sensor_pid} ->
+        # Fire off an initial measurement
+        send(sensor_pid, :do_sample)
+        {:ok, sensor_pid}
+
+      other ->
+        other
+    end
   end
 
   @doc """
@@ -133,7 +141,7 @@ defmodule SHT4X do
       }
 
       interval = Keyword.get(init_arg, :measurement_interval, @default_interval)
-      {:ok, _tref} = :timer.send_interval(interval, :do_measure)
+      {:ok, _tref} = :timer.send_interval(interval, :do_sample)
 
       Logger.info(
         "[SHT4X] Initializing | S/N: #{serial_number} | Options: #{inspect(state.options)}"

--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -91,15 +91,7 @@ defmodule SHT4X do
         :stale_threshold
       ])
 
-    case GenServer.start_link(__MODULE__, init_arg, gen_server_opts) do
-      {:ok, sensor_pid} ->
-        # Fire off an initial measurement
-        send(sensor_pid, :do_sample)
-        {:ok, sensor_pid}
-
-      other ->
-        other
-    end
+    GenServer.start_link(__MODULE__, init_arg, gen_server_opts)
   end
 
   @doc """
@@ -142,6 +134,8 @@ defmodule SHT4X do
         transport: transport
       }
 
+      # Request an initial sample and schedule the following ones.
+      send(self(), :do_sample)
       interval = Keyword.get(init_arg, :measurement_interval, @default_interval)
       {:ok, _tref} = :timer.send_interval(interval, :do_sample)
 

--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -65,7 +65,7 @@ defmodule SHT4X do
     raw_reading_temperature: 0,
     temperature_c: 23.0,
     humidity_rh: 50,
-    dew_point_c: 32,
+    dew_point_c: 12.02,
     quality: :unusable
   }
 
@@ -103,10 +103,12 @@ defmodule SHT4X do
   end
 
   @doc """
-  Fetches the latest sample from the sensor's GenServer.
-  NOTE: This does not cause an on-demand read from the sensor.
+  Fetches the latest sample from the sensor's GenServer
+
+  This does not cause an on-demand read from the sensor. Check the `:quality`
+  field for a quick assessment of how much to trust the measurement.
   """
-  @spec get_sample(GenServer.server()) :: SHT4X.Measurement.t() | {:error, :no_data}
+  @spec get_sample(GenServer.server()) :: SHT4X.Measurement.t()
   def get_sample(sensor_ref) do
     GenServer.call(sensor_ref, :get_sample)
   end

--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -14,18 +14,21 @@ defmodule SHT4X do
 
   @typedoc """
   How "fresh" is the sample we fetched from the sensor's GenServer?
+
   In the event that the sensor fails to report back a measurement during a polling interval, we re-use the last sample.
   If this continues to happen over a time period that exceeds the `:stale_threshold`, we mark the re-used "current" sample as stale.
 
   The possible values can be:
-  - `:fresh` - The sample is less than 60 sec. old
-  - `:stale` - The sample is more than 60 sec. old
-  - `:unusable` - The sample is a hard-coded sample value, and shouldn't be used
+  - `:fresh` - This is a recent sample. See the `:stale_threshold`.
+  - `:stale` - This is an old sample that should be used with caution.
+  - `:unusable` - This is a default sample when no measurements are available.
+  - `:converging` - This is optionally set by the temperature compensation algorithm to indicate that it was recently restarted without historic state information and needs more time to give accurate values
   """
-  @type quality :: :fresh | :stale | :unusable
+  @type quality :: :fresh | :stale | :unusable | :converging
 
   @typedoc """
   SHT4X GenServer start_link options
+
   * `:name` - a name for the GenServer
   * `:bus_name` - which I2C bus to use (e.g., `"i2c-1"`)
   * `:retries` - the number of retries before failing (defaults to 3 retries)

--- a/lib/sht4x/measurement.ex
+++ b/lib/sht4x/measurement.ex
@@ -12,6 +12,7 @@ defmodule SHT4X.Measurement do
     field(:raw_reading_temperature, integer, enforce: true)
     field(:raw_reading_humidity, integer, enforce: true)
     field(:timestamp_ms, integer, enforce: true)
+    field(:quality, SHT4X.quality(), enforce: true)
   end
 
   @doc """
@@ -33,7 +34,8 @@ defmodule SHT4X.Measurement do
       dew_point_c: SHT4X.Calc.dew_point(humidity_rh, temperature_c),
       raw_reading_temperature: raw_t,
       raw_reading_humidity: raw_rh,
-      timestamp_ms: timestamp_ms
+      timestamp_ms: timestamp_ms,
+      quality: :fresh
     )
   end
 


### PR DESCRIPTION
* Adds a `quality` field to the `Measurement` struct.
  * All samples from the sensor are `:fresh` by default.
* Every time we fail to read data from the sensor, we check to see if the current sample has been held as the current one for too long. If it has been, we mark its quality as `:stale`.
  * The default staleness threshold is `60_000`ms, this can be configured with `options`.
* The server starts out with a hard-coded `:unusable` value, in the event that the first read is a failure.
  * `:unusable` values are never fed into the compensation callback.
* An initial sensor read is fired on startup. 