### PR TITLE
Ensure we return floats in the hard coded unusable sample

### DIFF
--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -67,7 +67,7 @@ defmodule SHT4X do
     raw_reading_humidity: 0,
     raw_reading_temperature: 0,
     temperature_c: 23.0,
-    humidity_rh: 50,
+    humidity_rh: 50.0,
     dew_point_c: 12.02,
     quality: :unusable
   }

--- a/lib/sht4x/calc.ex
+++ b/lib/sht4x/calc.ex
@@ -37,7 +37,7 @@ defmodule SHT4X.Calc do
       iex> SHT4X.Calc.dew_point(50, 22.0) |> round()
       11
   """
-  @spec dew_point(number(), number()) :: float()
+  @spec dew_point(float(), float()) :: float()
   def dew_point(humidity_rh, temperature_c) when is_number(humidity_rh) and humidity_rh > 0 do
     log_rh = :math.log(humidity_rh / 100)
     t = temperature_c

--- a/lib/sht4x/measurement.ex
+++ b/lib/sht4x/measurement.ex
@@ -6,9 +6,9 @@ defmodule SHT4X.Measurement do
   use TypedStruct
 
   typedstruct do
-    field(:dew_point_c, number)
-    field(:humidity_rh, number, enforce: true)
-    field(:temperature_c, number, enforce: true)
+    field(:dew_point_c, float)
+    field(:humidity_rh, float, enforce: true)
+    field(:temperature_c, float, enforce: true)
     field(:raw_reading_temperature, integer, enforce: true)
     field(:raw_reading_humidity, integer, enforce: true)
     field(:timestamp_ms, integer, enforce: true)


### PR DESCRIPTION
Ran into an issue in an application where we were expecting a float, but this hard coded unusable value returns an integer... whoops 😅 

(there's no case where this value won't be a float)