### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2024-01-16
+
+### Changed
+
+* Updated dependencies.
+* `circuits_i2c` - either version 1.x or 2.x can now be used with this library.
+
 ## [0.2.2] - 2023-11-28
 
 ### Changed
@@ -75,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.2.3]: https://github.com/elixir-sensors/sht4x/compare/v0.2.2..v0.2.3
 [0.2.2]: https://github.com/elixir-sensors/sht4x/compare/v0.2.1..v0.2.2
 [0.2.1]: https://github.com/elixir-sensors/sht4x/compare/v0.2.0..v0.2.1
 [0.2.0]: https://github.com/elixir-sensors/sht4x/compare/v0.1.4..v0.2.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SHT4X.MixProject do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.2.3"
   @source_url "https://github.com/elixir-sensors/sht4x"
   @sht4x_datasheet_url "https://developer.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT4x_Datasheet.pdf"
 


### PR DESCRIPTION
### Changed

* Updated dependencies.
* `circuits_i2c` - either version 1.x or 2.x can now be used with this library.