### PR TITLE
Simplify response package handling

### DIFF
--- a/lib/sht4x/measurement.ex
+++ b/lib/sht4x/measurement.ex
@@ -32,7 +32,7 @@ defmodule SHT4X.Measurement do
   interpreted temperature and humidity.  It does not apply any compensation so
   this is real temperature and humidity detected.
   """
-  def from_raw(<<raw_t::16, _crc1, raw_rh::16, _crc2>>) do
+  def from_raw(<<raw_t::16, raw_rh::16>>) do
     timestamp_ms = System.monotonic_time(:millisecond)
 
     if raw_reading_valid?(raw_t, raw_rh) do

--- a/test/sht4x/measurement_test.exs
+++ b/test/sht4x/measurement_test.exs
@@ -5,7 +5,7 @@ defmodule SHT4X.MeasurementTest do
   doctest Measurement
 
   test "converts raw measurement" do
-    result = Measurement.from_raw(<<101, 233, 234, 109, 229, 160>>)
+    result = Measurement.from_raw(<<101, 233, 109, 229>>)
 
     assert result.quality == :fresh
     assert result.raw_reading_temperature == 26_089
@@ -17,22 +17,22 @@ defmodule SHT4X.MeasurementTest do
   end
 
   test "detects possible damaged sensor by looking for 0x8000 in both RH and Temp values" do
-    result = Measurement.from_raw(<<128, 0, 162, 128, 0, 162>>)
+    result = Measurement.from_raw(<<128, 0, 128, 0>>)
     assert result.quality == :unusable
   end
 
   test "detects possible damaged sensor by looking for 0x8001 in raw Temp value, and 0x8000 in raw Rh value" do
-    result = Measurement.from_raw(<<128, 1, 162, 128, 0, 162>>)
+    result = Measurement.from_raw(<<128, 1, 128, 0>>)
     assert result.quality == :unusable
   end
 
   test "detects possible damaged sensor by looking for values outside of operating range (Rh)" do
-    result = Measurement.from_raw(<<101, 233, 234, 0xFF, 0xFF, 172>>)
+    result = Measurement.from_raw(<<101, 233, 0xFF, 0xFF>>)
     assert result.quality == :unusable
   end
 
   test "detects possible damaged sensor by looking for values outside of operating range (C)" do
-    result = Measurement.from_raw(<<0xFF, 0xFF, 172, 109, 229, 160>>)
+    result = Measurement.from_raw(<<0xFF, 0xFF, 109, 229>>)
     assert result.quality == :unusable
   end
 


### PR DESCRIPTION
There were a few places that ignored CRCs and you have to know that
they're all ok when reading the code since they were checked earlier.
This change removes CRCs after they're checked, so the ignored CRC
places can be removed. No CRCs in the binary means all good.
