### PR TITLE
Only retry transactions on CRC Mismatch

### DIFF
--- a/lib/sht4x/comm.ex
+++ b/lib/sht4x/comm.ex
@@ -43,7 +43,8 @@ defmodule SHT4X.Comm do
 
   defp repeat_transaction(transport, command, delay_ms, retries) do
     case do_transaction(transport, command, delay_ms) do
-      {:error, _any_reason} when retries > 0 ->
+      # only retry in the event of a CRC mismatch
+      {:error, :crc_mismatch} when retries > 0 ->
         repeat_transaction(transport, command, delay_ms, retries - 1)
 
       result ->


### PR DESCRIPTION
This prevents i2c nacs, bus hangs and other similar issues from doing retries that will never complete