### PR TITLE
Reject more known bad values

### DIFF
--- a/lib/sht4x/measurement.ex
+++ b/lib/sht4x/measurement.ex
@@ -95,9 +95,18 @@ defmodule SHT4X.Measurement do
   end
 
   # Function to check the raw values read from the sensor
-  # A few bad values are known: 0x8000 and 0x8001 (according to Sensirion)
-  defp raw_reading_valid?(0x8000, 0x8000), do: false
-  defp raw_reading_valid?(0x8001, 0x8000), do: false
+  #
+  # A few bad values are known to exist on sensors that otherwise look like
+  # they're working. These correspond to around 40C and 55% rh, so they're unlikely,
+  # but not obviously broken. Seen bad temperature and humidity raw values are:
+  #
+  #   - 0x8000, 0x8000
+  #   - 0x8001, 0x8000
+  #   - 0x8002, 0x8002
+  #   - 0x8003, 0x8002
+  defp raw_reading_valid?(t, rh)
+       when t >= 0x8000 and t <= 0x8003 and rh >= 0x8000 and rh <= 0x8003,
+       do: false
 
   # Ensure raw values would be within min/max operating ranges
   defp raw_reading_valid?(t, _rh) when t not in @min_raw_t..@max_raw_t, do: false

--- a/test/sht4x/measurement_test.exs
+++ b/test/sht4x/measurement_test.exs
@@ -31,6 +31,11 @@ defmodule SHT4X.MeasurementTest do
     assert result.quality == :unusable
   end
 
+  test "detects possible damaged sensor by looking for 0x8003 in raw Temp value, and 0x8002 in raw Rh value" do
+    result = Measurement.from_raw(<<128, 3, 128, 2>>)
+    assert result.quality == :unusable
+  end
+
   test "detects possible damaged sensor by looking for values outside of operating range (Rh)" do
     result = Measurement.from_raw(<<101, 233, 0xFF, 0xFF>>)
     assert result.quality == :unusable


### PR DESCRIPTION
This adds more bad values that were seen on an SHT41. The 0x8002/0x8002
response would sometimes oscillate with 0x8003, but it was stuck on the
sensor. This led to constant 40C reports when the temperature wasn't
close to that.

This change just rejects any combinations where the temperature and
humidity are the magic values to head off other variations.
