### PR TITLE
Add telemetry to temperature measurements

### DIFF
--- a/lib/sht4x.ex
+++ b/lib/sht4x.ex
@@ -174,30 +174,47 @@ defmodule SHT4X do
 
   @impl GenServer
   def handle_info(:do_sample, state) do
+    event_name = [:sht4x, :measure]
+
+    event_name
+    |> :telemetry.span(%{}, fn ->
+      state.transport
+      |> SHT4X.Comm.measure(state.options)
+      |> process_measurement(state)
+      |> report_telemetry(event_name)
+    end)
+    |> then(&{:noreply, &1})
+  end
+
+  defp process_measurement({:ok, data}, state) do
+    measurement_raw = SHT4X.Measurement.from_raw(data)
     compensation_callback = state.options[:compensation_callback]
+    measurement_compensated = compensation_callback.(measurement_raw)
 
-    case SHT4X.Comm.measure(state.transport, state.options) do
-      {:ok, data} ->
-        measurement_raw = SHT4X.Measurement.from_raw(data)
-        measurement_compensated = compensation_callback.(measurement_raw)
+    %{
+      state
+      | current_measurement: measurement_compensated,
+        current_raw_measurement: measurement_raw
+    }
+  end
 
-        {:noreply,
-         %{
-           state
-           | current_measurement: measurement_compensated,
-             current_raw_measurement: measurement_raw
-         }}
-
-      _error ->
-        # Always call the compensation function on the last good raw reading we had, if there is one.
-        # Unless the quality of that sample is unusable.
-        if state.current_raw_measurement.quality == :unusable do
-          {:noreply, state}
-        else
-          measurement_compensated = compensation_callback.(state.current_raw_measurement)
-          check_staleness(state, measurement_compensated)
-        end
+  defp process_measurement(_error, state) do
+    # Always call the compensation function on the last good raw reading we had, if there is one.
+    # Unless the quality of that sample is unusable.
+    if state.current_raw_measurement.quality == :unusable do
+      state
+    else
+      compensation_callback = state.options[:compensation_callback]
+      measurement_compensated = compensation_callback.(state.current_raw_measurement)
+      check_staleness(state, measurement_compensated)
     end
+  end
+
+  defp report_telemetry(state, event_name) do
+    telemetry_measurements = Map.take(state, [:current_measurement, :current_raw_measurement])
+    telemetry_metadata = %{system_time: System.monotonic_time()}
+    :telemetry.execute(event_name, telemetry_measurements, telemetry_metadata)
+    {state, %{}}
   end
 
   defp check_staleness(state, measurement_compensated) do
@@ -205,14 +222,13 @@ defmodule SHT4X do
 
     if now - measurement_compensated.timestamp_ms >= state.options[:stale_threshold] do
       # Mark the current samples as stale
-      {:noreply,
-       %{
-         state
-         | current_measurement: %{measurement_compensated | quality: :stale},
-           current_raw_measurement: %{state.current_raw_measurement | quality: :stale}
-       }}
+      %{
+        state
+        | current_measurement: %{measurement_compensated | quality: :stale},
+          current_raw_measurement: %{state.current_raw_measurement | quality: :stale}
+      }
     else
-      {:noreply, %{state | current_measurement: measurement_compensated}}
+      %{state | current_measurement: measurement_compensated}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,8 @@ defmodule SHT4X.MixProject do
       {:circuits_sim, "~> 0.1.2", only: [:dev, :test]},
       {:ex_doc, "~> 0.28", only: :docs, runtime: false},
       {:cerlc, "~> 0.2.0"},
-      {:typed_struct, "~> 0.3.0"}
+      {:typed_struct, "~> 0.3.0"},
+      {:telemetry, "~> 1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -18,5 +18,6 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.2", "03e1804074b3aa64d5fad7aa64601ed0fb395337b982d9bcf04029d68d51b6a7", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "af33ff7ef368d5893e4a267933e7744e46ce3cf1f61e2dccf53a111ed3aa3727"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
+  "telemetry": {:hex, :telemetry, "1.3.0", "fedebbae410d715cf8e7062c96a1ef32ec22e764197f70cda73d82778d61e7a2", [:rebar3], [], "hexpm", "7015fc8919dbe63764f4b4b87a95b7c0996bd539e0d499be6ec9d7f3875b79e6"},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
 }

--- a/test/sht4x_test.exs
+++ b/test/sht4x_test.exs
@@ -11,8 +11,20 @@ defmodule SHT4XTest do
 
   @i2c_bus "i2c-1"
   @i2c_address 0x44
+  @telemetry_event_prefix [:sht4x, :measure]
 
-  setup do
+  setup %{test: test} do
+    self = self()
+
+    :telemetry.attach(
+      "#{test}",
+      @telemetry_event_prefix,
+      fn name, measurements, metadata, _ ->
+        send(self, {:telemetry_event, name, measurements, metadata})
+      end,
+      nil
+    )
+
     SHT4XSim.inject_crc_errors(@i2c_bus, @i2c_address, 0)
     SHT4XSim.set_broken(@i2c_bus, @i2c_address, nil)
   end
@@ -27,6 +39,7 @@ defmodule SHT4XTest do
     assert measurement.quality == :fresh
     assert_in_delta measurement.humidity_rh, 33.3, 0.1
     assert_in_delta measurement.temperature_c, 11.1, 0.1
+    assert_telemetry_event(:fresh, 20_604, 21_008)
   end
 
   test "recovers from one crc error" do
@@ -40,6 +53,7 @@ defmodule SHT4XTest do
     assert measurement.quality == :fresh
     assert_in_delta measurement.humidity_rh, 33.3, 0.1
     assert_in_delta measurement.temperature_c, 11.1, 0.1
+    assert_telemetry_event(:fresh, 20_604, 21_008)
   end
 
   test "fails on crc errors on two transactions" do
@@ -54,6 +68,7 @@ defmodule SHT4XTest do
 
     measurement = SHT4X.get_sample(sht_pid)
     assert measurement.quality == :unusable
+    assert_telemetry_event(:unusable, 0, 0)
   end
 
   test "reading the simulated serial number" do
@@ -83,5 +98,28 @@ defmodule SHT4XTest do
 
     measurement = SHT4X.get_sample(sht_pid)
     assert measurement.quality == :unusable
+    assert_telemetry_event(:unusable, 0, 0)
+  end
+
+  defp assert_telemetry_event(measure_quality, expected_raw_humidity, expected_raw_temperature) do
+    assert_receive {:telemetry_event, @telemetry_event_prefix,
+                    %{
+                      current_measurement: %{
+                        quality: ^measure_quality,
+                        raw_reading_humidity: ^expected_raw_humidity,
+                        raw_reading_temperature: ^expected_raw_temperature,
+                        temperature_c: _,
+                        humidity_rh: _,
+                        dew_point_c: _
+                      },
+                      current_raw_measurement: %{
+                        quality: ^measure_quality,
+                        raw_reading_humidity: ^expected_raw_humidity,
+                        raw_reading_temperature: ^expected_raw_temperature,
+                        temperature_c: _,
+                        humidity_rh: _,
+                        dew_point_c: _
+                      }
+                    }, %{}}
   end
 end


### PR DESCRIPTION
Emitting some `:telemetry` events so that we can attach handlers to them in firmware.