### PR TITLE
Add new bad value (0x9000,0x9000) that was seen

### DIFF
--- a/lib/sht4x/measurement.ex
+++ b/lib/sht4x/measurement.ex
@@ -104,8 +104,15 @@ defmodule SHT4X.Measurement do
   #   - 0x8001, 0x8000
   #   - 0x8002, 0x8002
   #   - 0x8003, 0x8002
+  #
+  #   - 0x9000, 0x9000
+  #   - Guessing that 0x9001 to 0x9003 are possible even though they haven't been seen
   defp raw_reading_valid?(t, rh)
        when t >= 0x8000 and t <= 0x8003 and rh >= 0x8000 and rh <= 0x8003,
+       do: false
+
+  defp raw_reading_valid?(t, rh)
+       when t >= 0x9000 and t <= 0x9003 and rh >= 0x9000 and rh <= 0x9003,
        do: false
 
   # Ensure raw values would be within min/max operating ranges

--- a/test/sht4x/measurement_test.exs
+++ b/test/sht4x/measurement_test.exs
@@ -36,6 +36,11 @@ defmodule SHT4X.MeasurementTest do
     assert result.quality == :unusable
   end
 
+  test "detects possible damaged sensor by looking for 0x9000 in raw Temp value, and 0x9000 in raw Rh value" do
+    result = Measurement.from_raw(<<144, 0, 144, 0>>)
+    assert result.quality == :unusable
+  end
+
   test "detects possible damaged sensor by looking for values outside of operating range (Rh)" do
     result = Measurement.from_raw(<<101, 233, 0xFF, 0xFF>>)
     assert result.quality == :unusable


### PR DESCRIPTION
The sensor would repeatedly report 0x9000 for both temperature and
humidity. It wasn't close to 55C/125F.
