### PR TITLE
v0.3.3 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2025-10-12
+
+### Changed
+
+* Add more magic numbers (0x9000 - 0x9003) that indicate a bad measurement from
+  the sensor and should be dropped.
+
 ## [0.3.2] - 2025-05-01
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SHT4X.MixProject do
   use Mix.Project
 
-  @version "0.3.2"
+  @version "0.3.3"
   @source_url "https://github.com/elixir-sensors/sht4x"
   @reuse_compliance_url "https://api.reuse.software/info/github.com/elixir-sensors/sht4x"
   @sht4x_datasheet_url "https://developer.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT4x_Datasheet.pdf"


### PR DESCRIPTION
## [0.3.3] - 2025-10-12

### Changed

* Add more magic numbers (0x9000 - 0x9003) that indicate a bad measurement from
  the sensor and should be dropped.