### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SHT4X
 
 [![Hex version](https://img.shields.io/hexpm/v/sht4x.svg "Hex version")](https://hex.pm/packages/sht4x)
-[![API docs](https://img.shields.io/hexpm/v/sht4x.svg?label=hexdocs "API docs")](https://hexdocs.pm/sht4x/SHT4X.html)
+[![API docs](https://img.shields.io/hexpm/v/sht4x.svg?label=hexdocs "API docs")](https://sht4x.hexdocs.pm/SHT4X.html)
 [![CircleCI](https://circleci.com/gh/elixir-sensors/sht4x.svg?style=svg)](https://circleci.com/gh/elixir-sensors/sht4x)
 [![REUSE status](https://api.reuse.software/badge/github.com/elixir-sensors/sht4x)](https://api.reuse.software/info/github.com/elixir-sensors/sht4x)
 
@@ -25,4 +25,4 @@ iex> SHT4X.get_sample(sht)
 }
 ```
 
-For details, see [API reference](https://hexdocs.pm/sht4x/api-reference.html).
+For details, see [API reference](https://sht4x.hexdocs.pm/api-reference.html).


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://sht4x.hexdocs.pm/SHT4X.html): Status 404
❌ Verification failed for https://sht4x.hexdocs.pm/api-reference.html): Status 404
⚠️ Verification finished: 0 success, 2 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>